### PR TITLE
Assorted devenv improvements.

### DIFF
--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Prepare Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-devenv
       - name: Docker Build
         uses: docker/build-push-action@v2
         with:
@@ -47,3 +52,9 @@ jobs:
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: ${{ env.publish }}
           tags: netdata/devenv:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Cleanup Cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/devenv.yml
+++ b/.github/workflows/devenv.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Determine if we should push changes and which tags to use
-        if: github.event_name == 'workflow_dispatch' || github.event.inputs.version == 'push'
+        if: (github.event_name == 'workflow_dispatch' || github.event.name == 'push' || github.event.name == 'schedule') && secrets.DOCKER_USERNAME !+ '' && secrets.DOCKER_TOKEN != ''
         run: |
           echo "publish=true" >> $GITHUB_ENV
       - name: Determine if we should push changes and which tags to use
-        if: github.event_name != 'workflow_dispatch' && github.event_name != 'push'
+        if: env.publish != 'true'
         run: |
           echo "publish=false" >> $GITHUB_ENV
       - name: Setup QEMU
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1
       - name: Docker Hub Login
-        if: github.event_name == 'workflow_dispatch'
+        if: env.publish == 'true'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -1,22 +1,35 @@
-FROM ubuntu:latest
+FROM ubuntu:20.10
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="${PATH}:/usr/local/go/bin"
 
 WORKDIR /root/
 # hadolint ignore=DL3005,DL3008
-# Dependencies required for netdata/netdata, netdata/go.d.plugin
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends git apt-utils curl tar wget yamllint shellcheck flake8 golang python3-pip ca-certificates  && rm -rf /var/lib/apt/lists/*
-RUN curl -o ./install-required-packages.sh https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh && chmod +x ./install-required-packages.sh && ./install-required-packages.sh netdata-all --non-interactive
-# Hadolint is vendored only for x86_64 architectures
-RUN  [ "$(uname -m)" = "x86_64" ] && curl -o /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.22.0/hadolint-Linux-x86_64 && chmod +x /bin/hadolint; true
-RUN export PATH=$PATH:/usr/local/go/bin
-RUN go version
-# Dependencies required for netdata/dashboard
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN apt install -y --no-install-recommends yarn nodejs
-RUN npm install --global --unsafe-perm --force yarn 
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends apt-utils \
+                                               ca-certificates \
+                                               curl \
+                                               gnupg \
+                                               lsb-release && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - && \
+    echo "deb https://deb.nodesource.com/node_14.x $(lsb_release -s -c) main" | sudo tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends flake8 \
+                                               golang \
+                                               python3-pip \
+                                               nodejs \
+                                               shellcheck \
+                                               yamllint && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
+    npm install --global --unsafe-perm --force yarn && \
+    [ "$(uname -m)" = "x86_64" ] && curl -o /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v1.23.0/hadolint-Linux-x86_64 && chmod +x /bin/hadolint; true
 
+RUN curl -o ./install-required-packages.sh https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh && \
+    chmod +x ./install-required-packages.sh && \
+    ./install-required-packages.sh netdata-all --non-interactive --dont-wait && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 EXPOSE 19999
-ENTRYPOINT ["tail", "-f", "/dev/null"]
 
+CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
* Fixed the conditionals in the devenv GHA workflow to make sure things run only when they are supposed to.
* Added build caching to the devenv GHA workflow. This will make life easier for users and greatly speed up our build process (still needs some improvement so we handle OS-level updates properly).
* Switched to specifically using Ubuntu 20.10 instead of the `latest` tag. This will let us provide a more stable environment.
* Updated hadolint version to 1.23.0 (was 1.22.0)
* Updated Node.js version to 14.x (was 12.x)
* Added proper cleanup of APT caches (we were only dropping package lists, we’re now also getting rid of cached package files as well).
* Reformatted the `RUN` lines in the Dockerfile to be more readable.
* Consolidated the `RUN` lines to reduce the total layer count and avoid having to re-run things over and over again.
* Shifted to using an `ADD` line for `install-required-packages.sh`. This ensures it will be pulled over each time the image is built, helping to ensure we do not have any issues due to caching.
* Switched to manual setup of the NodeSource repo. This is not only faster, but also lets us avoid pulling in things we don’t need.
* Switched to using an `ENV` line to update `$PATH` instead of a `RUN` line with an `export` command (mostly just for consistency reasons, but this also speeds up the build a tiny bit).
* Dropped some commands that were not actually making any contribution to the process of building the image.

---

All together, this ends up reducing the final x86_64 image size by 365MB and eliminates 3 layers from the image. Savings are similar for other architectures.