### PR TITLE
[Ansible] Full Netdata agent configuration support

### DIFF
--- a/netdata-agent-deployment/ansible-quickstart/README.md
+++ b/netdata-agent-deployment/ansible-quickstart/README.md
@@ -47,26 +47,21 @@ When the playbook finishes, you'll see your nodes appear in Netdata Cloud!
 
 ## Configuration
 
-If you want to further configure your Netdata Agents, you can edit the existing values in `vars/main.yml`, or create new
-ones. If you create new values, you should then also edit `templates/netdata.conf.j2` to add them to the configuration
-file that is copied to each node. See the [daemon configuration
-doc](https://learn.netdata.cloud/docs/agent/daemon/config) for details about each setting.
+If you want to further configure your Netdata Agents, you can edit the existing values in `vars/main.yml`.
+You should match you config keys under `config` to the netdata configuration sections mentioned [here](https://learn.netdata.cloud/docs/agent/daemon/config)
+
+Plugins require `enabled: yes` to be created and configured.
+
+Each entry should have a `data` key which include the configuration in the Netdata key = value format.
 
 For example, if you want to increase metrics retention, increase `dbengine_multihost_disk_space` and run the playbook
 again.
 
-You could also create entirely new templates with this method. For example, if you want to control the
-`health_alarm_notify.conf` script with this playbook, create a new file called `templates/health_alarm_notify.conf` and
-add the settings you want to control. Add relevant variables to `vars/main.yml`, then create a new template task in
-`tasks/configure.yml`:
+```
+config:
+  global:
+    data: |-
 
-```yml
-  - template:
-      src: ../templates/health_alarm_notify.conf.j2
-      dest: /etc/netdata/health_alarm_notify.conf
-      owner: root
-      group: root
-      mode: u=wrx,g=rx,o=r,+x
-    notify: Restart Netdata
-    become: true
+      dbengine_multihost_disk_space = 2048
+
 ```

--- a/netdata-agent-deployment/ansible-quickstart/tasks/claim.yml
+++ b/netdata-agent-deployment/ansible-quickstart/tasks/claim.yml
@@ -3,8 +3,7 @@
   hosts: all
   vars_files:
     - "../vars/main.yml"
-  become: true
-  become_method: sudo
+
 
   tasks:
   - name: Claim to Netdata Cloud
@@ -19,7 +18,6 @@
     - name: Claim to Netdata Cloud
       shell: netdata-claim.sh -token={{ claim_token }} -rooms={{ claim_rooms }} -url={{ claim_url }}
       when: claimed_result.stat.exists == false
-      become: yes
     when: reclaim == false
 
   - name: Re-claim a node to Netdata Cloud
@@ -39,11 +37,12 @@
       shell: netdata-claim.sh -token={{ claim_token }} -rooms={{ claim_rooms }} -url={{ claim_url }} -id=$(uuidgen)
       when: uuidgen_result.stat.exists == true
       notify: Restart Netdata
-      become: yes
     when: reclaim == true
+    tags: claim
 
   handlers:
   - name: Restart Netdata
     service:
       name: netdata
       state: restarted
+  tags: claim

--- a/netdata-agent-deployment/ansible-quickstart/tasks/configure.yml
+++ b/netdata-agent-deployment/ansible-quickstart/tasks/configure.yml
@@ -3,8 +3,7 @@
   hosts: all
   vars_files:
     - "../vars/main.yml"
-  become: true
-  become_method: sudo
+  tags: config
 
   tasks:
   - template:
@@ -14,7 +13,7 @@
       group: root
       mode: u=wrx,g=rx,o=r,+x
     notify: Restart Netdata
-    become: true
+    tags: config
   
   handlers:
   - name: Restart Netdata

--- a/netdata-agent-deployment/ansible-quickstart/tasks/install.yml
+++ b/netdata-agent-deployment/ansible-quickstart/tasks/install.yml
@@ -3,8 +3,6 @@
   hosts: all
   vars_files:
     - "../vars/main.yml"
-  become: true
-  become_method: sudo
 
   tasks:
   - name: Download the installation script
@@ -12,11 +10,14 @@
       url: https://my-netdata.io/kickstart.sh
       dest: ~/kickstart.sh
       mode: +x
+    tags: install
 
   - name: Install Netdata
     command: ~/kickstart.sh --dont-wait
+    tags: install
 
   - name: Cleanup installation script
     file:
       path: ~/kickstart.sh
       state: absent
+    tags: install

--- a/netdata-agent-deployment/ansible-quickstart/tasks/main.yml
+++ b/netdata-agent-deployment/ansible-quickstart/tasks/main.yml
@@ -2,7 +2,10 @@
 # Tasks file for Netdata
 
 - import_playbook: install.yml
+  tags: install
 
 - import_playbook: configure.yml
+  tags: config
 
 - import_playbook: claim.yml
+  tags: claim

--- a/netdata-agent-deployment/ansible-quickstart/templates/netdata.conf.j2
+++ b/netdata-agent-deployment/ansible-quickstart/templates/netdata.conf.j2
@@ -1,10 +1,19 @@
-# Netdata configuration
+{%- for section in config if 'plugins' not in section  %}[{{section}}]
+{{ config[section].data|indent(4, true) }}
+{% endfor -%}
 
-[global]
-  {% if hostvars[inventory_hostname].hostname %}
-  hostname = {{ hostvars[inventory_hostname].hostname }}
-  {% endif %}
-  dbengine multihost disk space = {{ dbengine_multihost_disk_space }}
+{% if config.plugins is defined %}
+{% set plugins_section = [] %}
+{%- for plugin in config.plugins %}
+{% if config.plugins[plugin].enabled %}
+{% set key = plugins_section.append(plugin) %}
+[plugin:{{plugin}}]
+{{ config.plugins[plugin].data|indent(4, true) }}
+{% endif %}
+{% endfor -%}
 
-[web]
-	mode = {{ web_mode }}
+[plugins]
+{% for plugin in plugins_section %}
+{{ plugin|indent(4, true) }} = yes
+{% endfor -%}
+{% endif %}

--- a/netdata-agent-deployment/ansible-quickstart/vars/main.yml
+++ b/netdata-agent-deployment/ansible-quickstart/vars/main.yml
@@ -47,11 +47,11 @@ config:
       mode = none
   plugins:
     ioping:
-      enabled: yes
+      enabled: no
       data: |-
         update every = 1
     cgroups:
-      enabled: yes
+      enabled: no
       data: |-
         cgroups plugin resource charts = yes
         update every = 1

--- a/netdata-agent-deployment/ansible-quickstart/vars/main.yml
+++ b/netdata-agent-deployment/ansible-quickstart/vars/main.yml
@@ -16,14 +16,43 @@ claim_url: https://app.netdata.cloud
 # https://learn.netdata.cloud/docs/agent/claim#remove-and-reclaim-a-node
 reclaim: false
 
-# Set Netdata's metrics retention policy via the disk size for the database
-# engine. Value is in MiB. Read more:
-# https://learn.netdata.cloud/docs/store/change-metrics-storage
-dbengine_multihost_disk_space: 2048
+config:
+  global:
+    data: |-
+      run as user = netdata
+      {% if hostvars[inventory_hostname].hostname %}
+      hostname = {{ hostvars[inventory_hostname].hostname }}
+      {% else %}
+      hostname = ansible.netdata.cloud
+      {% endif %}
 
-# Set whether to run the Agent web server/dashboard/API, or disable them.
-# Because we're connecting this node to Netdata Cloud and will view dashboards
-# there, we'll set this to `none` to disable the local dashboard. Set to
-# `static-threaded` if you want to keep it running. Read more:
-# https://learn.netdata.cloud/docs/configure/secure-nodes
-web_mode: none
+      history = 172956
+      process nice level = 0
+
+      # Set Netdata's metrics retention policy via the disk size for the database
+      # engine. Value is in MiB. Read more:
+      # https://learn.netdata.cloud/docs/store/change-metrics-storage
+      dbengine_multihost_disk_space = 2048
+  web:
+    data: |-
+      web files owner = root
+      web files group = netdata
+      disconnect idle clients after seconds = 3600
+      bind to = localhost
+      # Set whether to run the Agent web server/dashboard/API, or disable them.
+      # Because we're connecting this node to Netdata Cloud and will view dashboards
+      # there, we'll set this to `none` to disable the local dashboard. Set to
+      # `static-threaded` if you want to keep it running. Read more:
+      # https://learn.netdata.cloud/docs/configure/secure-nodes
+      mode = none
+  plugins:
+    ioping:
+      enabled: yes
+      data: |-
+        update every = 1
+    cgroups:
+      enabled: yes
+      data: |-
+        cgroups plugin resource charts = yes
+        update every = 1
+        check for new cgroups every = 10


### PR DESCRIPTION
With these changes you can use the template to generate the entire Netdata agent configuration overrides.
Netdata dropped the use `root` user So no need to `become`
You can also run it with `install` , `claim` or `config` tags.

Unfortunately i could not completely convert the entire YAML based Ansible var to Netdata configuration easily with this change (whitespace in keys). So at least i consolidate the plugins and per plugin config. and i divided the config keys to match Netdata config sections.

Ref: netdata/infra#1831
