### PR TITLE
Update deprecated install option

### DIFF
--- a/devenv/bash_aliases
+++ b/devenv/bash_aliases
@@ -15,5 +15,5 @@ alias nconf="CFLAGS=\"${NETDATA_DEV_CFLAGS}\" ./configure \
         --with-math \
         --with-user=netdata \
         --disable-lto"
-alias netdata-install="CFLAGS='${NETDATA_DEV_CFLAGS}' ./netdata-installer.sh --install $NETDATA_INSTALL_PREFIX --dont-start-it --dont-wait --disable-lto"
+alias netdata-install="CFLAGS='${NETDATA_DEV_CFLAGS}' ./netdata-installer.sh --install-prefix $NETDATA_INSTALL_PREFIX --dont-start-it --dont-wait --disable-lto"
 alias netdata-build="nreconf && nconf && make"


### PR DESCRIPTION
Reflect https://github.com/netdata/netdata/pull/13881 changes to make the `netdata-install` alias work.