### PR TITLE
collectors: add other collectors (needrestart, debsecan, logcount, apt)

### DIFF
--- a/collectors/README.md
+++ b/collectors/README.md
@@ -41,3 +41,12 @@ Alternatively you can use [this helper script](/utilities/install-collector.sh) 
 # download and install the clickhouse collector
 sudo wget -O /tmp/install-collector.sh https://raw.githubusercontent.com/netdata/community/main/utilities/install-collector.sh && sudo bash /tmp/install-collector.sh python.d.plugin/clickhouse
 ```
+
+## Other collectors
+
+These community plugins are maintained in separate repositories and come with their own installation instructions.
+
+- [netdata-needrestart](https://github.com/nodiscc/netdata-needrestart) - Check/graph the number of processes/services/kernels that should be restarted after upgrading packages.
+- [netdata-debsecan](https://github.com/nodiscc/netdata-debsecan) - Check/graph the number of CVEs in currently installed packages.
+- [netdata-logcount](https://github.com/nodiscc/netdata-logcount) - Check/graph the number of syslog messages, by level over time.
+- [netdata-apt](https://github.com/nodiscc/netdata-apt) - Check/graph and alert on the number of upgradeable packages, and available distribution upgrades.


### PR DESCRIPTION
Hi, I'd like to add these new plugins to the list of community-maintained collectors.

As these are maintained in separate repositories, I added an `Other collectors` section to `collectors/README.md`.

I have used the needrestart, debsecan and logcount plugins in production for years with good results.

- The main point of the `needrestart` plugin is to raise an alarm when a reboot is necessary to apply a kernel update, or restarting services is required to allow them to load updated shared libraries. These tasks are automatable, but depending on SLAs and other constraints it is not always desirable to automate them fully.
- The main point of the `debsecan` plugin is to have an indication of the global "vulnerability" level of a host over time. Note that all CVEs reported are not always applicable, have different severities, so manual investigation is needed to either fix the underlying issues, or whitelist a particular CVE through debsecan's whitelist. Looking at the chart does not replace reading debsecan reports, but it gives an insight on the attack surface of each host, and allows comaprisons between hosts.
- The main point of the `logcount` plugin is to have quick access to error/warning log message rates on each host. This is a very lightweight alternative to more complex systems like ELK/Graylog, where setting up a full log aggregation/analysis/SIEM is not possible, and is an improvement over reviewing logs manually.
- The main point of the `apt` plugin is to alert when some packages should be upgraded, or when a full distribution upgrade is in order. Again this process can be fully automated, but it is not always desirable (e.g. when using third-party repositories which require reading release notes and possibly applying manual changes). It also mitigates configuration errors in unattended-upgrades configuration (e.g. forgetting to allow automatic upgrades from a specific repository). This is the newest of my netdata plugins but it is working well so far.

The `needrestart`, `debsecan` and `apt` plugins are specific to Debian-based systems. All plugins have tagged releases so it is possible to run them without suffering breaking changes without notice. All plugins can be installed through the `nodiscc.xsrv.netdata` ansible role which is already [listed in this repository](https://github.com/netdata/community/tree/main/configuration-management/ansible-xsrv).

Please let me know if you have any questions improvements to suggest.