### PR TITLE
updated node.js installer command

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -12,10 +12,12 @@ RUN apt-get update && \
                                                curl \
                                                gnupg \
                                                lsb-release && \
-    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add - && \
-    echo "deb https://deb.nodesource.com/node_12.x $(lsb_release -s -c) main" | sudo tee /etc/apt/sources.list.d/nodesource.list && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    NODE_MAJOR=20 && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends flake8 \
+    apt-get install -y --no-install-recommends nodejs \
+                                               flake8 \
                                                golang \
                                                python3-pip \
                                                nodejs \


### PR DESCRIPTION
This dockerfile is referenced by the [devcontainer in the go.d repo](https://github.com/netdata/go.d.plugin/blob/master/.devcontainer/devcontainer.json) but it does not work.
When running in VS Code there is no Golang installed.
The cause was the node.js repo key install command was using a deprecated command.
Fixed that and bumped node.js version from 12 to 20.