### PR TITLE
Hadolint fixes for devenv

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
                                                yamllint && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     npm install --global --unsafe-perm --force yarn && \
-    [ "$(uname -m)" = "x86_64" ] && curl -o /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.1.0/hadolint-Linux-x86_64 && chmod +x /bin/hadolint; true
+    [ "$(uname -m)" = "x86_64" ] && curl -Lo /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.1.0/hadolint-Linux-x86_64 && chmod +x /bin/hadolint; true
 
 ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh /install-required-packages.sh
 

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && \
                                                yamllint && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     npm install --global --unsafe-perm --force yarn && \
-    [ "$(uname -m)" = "x86_64" ] && curl -Lo /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.1.0/hadolint-Linux-x86_64 && chmod +x /bin/hadolint; true
+    [ "$(uname -m)" = "x86_64" ] && curl -Lo /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 && chmod +x /bin/hadolint; true
 
 ADD https://raw.githubusercontent.com/netdata/netdata/master/packaging/installer/install-required-packages.sh /install-required-packages.sh
 


### PR DESCRIPTION
Fixed: Hadolint did not work as curl was creating a zero-kb downloaded file due to not following redirects.
Updated: bumped Hadolint version from /v2.1.0 to  v2.12.0.